### PR TITLE
Version check (torchvision) >= 0.10 error fix

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -33,7 +33,7 @@ from torch.nn.parallel import DistributedDataParallel
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.5:
+if float(torchvision.__version__.split('.')[1]) < 5:
     import math
     from torchvision.ops.misc import _NewEmptyTensorOp
     def _check_size_scale_factor(dim, size, scale_factor):
@@ -60,7 +60,7 @@ if float(torchvision.__version__[:3]) < 0.5:
         return [
             int(math.floor(input.size(i + 2) * scale_factors[i])) for i in range(dim)
         ]
-elif float(torchvision.__version__[:3]) < 0.7:
+elif float(torchvision.__version__.split('.')[1]) < 7:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 


### PR DESCRIPTION
**TL;DR** ) *Fixed `util/misc.py`\'s version checking method for `torchvision` to be compatible with `torchvision >= 0.10.0`*
 
Since I was interested in your paper, `Sparse DETR`, I was trying to run(train/test) model within `Google Colab` environment.

During the initial run, I found out that `torchvision` version checking method does not work as intended:
- My `torchvision` version was`0.10.1`, but the checking method treated as `0.1`.

Solved by replacing 
```
float(torchvision.__version__[:3]) < 0.5
```
with
```
float(torchvision.__version__.split('.')[1]) < 5
```
And for <0.7, similarly fixed.

Therefore, I request pull-request to fix this issue.

Thank you.
Taewoo Jeong.